### PR TITLE
Make ACK_RECEIVE_TIMESTAMPS frame Gap more efficient and QUIC-like.

### DIFF
--- a/quic/core/quic_framer.cc
+++ b/quic/core/quic_framer.cc
@@ -4188,10 +4188,11 @@ bool QuicFramer::ProcessIetfTimestampsInAckFrame(QuicPacketNumber largest_acked,
           return false;
         }
       }
-      visitor_->OnAckTimestamp(packet_number - j,
+      visitor_->OnAckTimestamp(packet_number,
                                creation_time_ + last_timestamp_);
+      packet_number--;
     }
-    packet_number = packet_number - (timestamp_count - 1);
+    packet_number--;
   }
   return true;
 }

--- a/quic/core/quic_framer_test.cc
+++ b/quic/core/quic_framer_test.cc
@@ -4113,7 +4113,7 @@ TEST_P(QuicFramerTest, AckFrameMultipleReceiveTimestampRanges) {
 
        // Timestamp range 2 (one packet).
        { "Unable to read receive timestamp gap.",
-         { kVarInt62OneByte + 0x07 }},
+         { kVarInt62OneByte + 0x05 }},
        { "Unable to read receive timestamp count.",
          { kVarInt62OneByte + 0x01 }},
        { "Unable to read receive timestamp delta.",
@@ -4121,7 +4121,7 @@ TEST_P(QuicFramerTest, AckFrameMultipleReceiveTimestampRanges) {
 
        // Timestamp range 3 (two packets).
        { "Unable to read receive timestamp gap.",
-         { kVarInt62OneByte + 0x0a }},
+         { kVarInt62OneByte + 0x08 }},
        { "Unable to read receive timestamp count.",
          { kVarInt62OneByte + 0x02 }},
        { "Unable to read receive timestamp delta.",


### PR DESCRIPTION
Per TBD IETF receive timestamp proposal:
https://github.com/wcsmith/draft-quic-receive-ts

   Gap:  A variable-length integer indicating the largest packet number
      in the Timestamp Range as follows:

      For the first Timestamp Range: Gap is the difference between (a)
      the Largest Acknowledged packet number in the frame and (b) the
      largest packet in the current (first) Timestamp Range.

      For subsequent Timestamp Ranges: Gap is the difference between (a)
      the packet number two lower than the smallest packet number in the
      previous Timestamp Range and (b) the largest packet in the current
      Timestamp Range.