### PR TITLE
Fix size_t / int64_t implicit cast compiler errors

### DIFF
--- a/http2/adapter/oghttp2_session.cc
+++ b/http2/adapter/oghttp2_session.cc
@@ -417,7 +417,7 @@ OgHttp2Session::ProcessBytesImpl(absl::string_view bytes) {
   RunOnExit r{[this]() { processing_bytes_ = false; }};
 
   if (options_.blackhole_data_on_connection_error && latched_error_) {
-    return bytes.size();
+    return static_cast<int64_t>(bytes.size());
   }
 
   int64_t preface_consumed = 0;
@@ -439,7 +439,7 @@ OgHttp2Session::ProcessBytesImpl(absl::string_view bytes) {
     if (!remaining_preface_.empty()) {
       QUICHE_VLOG(2) << "Preface bytes remaining: "
                      << remaining_preface_.size();
-      return min_size;
+      return static_cast<int64_t>(min_size);
     }
     preface_consumed = min_size;
   }
@@ -453,7 +453,7 @@ OgHttp2Session::ProcessBytesImpl(absl::string_view bytes) {
   if (latched_error_ || result < 0) {
     QUICHE_VLOG(2) << "ProcessBytes encountered an error.";
     if (options_.blackhole_data_on_connection_error) {
-      return bytes.size() + preface_consumed;
+      return static_cast<int64_t>(bytes.size()) + preface_consumed;
     } else {
       return ProcessBytesError::kUnspecified;
     }


### PR DESCRIPTION
`bytes.size()` returns a `size_t`, which may be different than the expected return type of `int64_t`. Fix this by making the cast explicit using `static_cast<int64_t>`.

See https://github.com/envoyproxy/envoy/pull/19360 and https://github.com/envoyproxy/envoy/pull/19408 for further discussion