### PR TITLE
Change flags type in Http2FrameHeaderTypeAndFlagTest

### DIFF
--- a/quiche/http2/http2_structures_test.cc
+++ b/quiche/http2/http2_structures_test.cc
@@ -151,7 +151,7 @@ TEST(Http2FrameHeaderTest, Eq) {
 // The tests of the valid frame types include EXPECT_DEBUG_DEATH, which is
 // quite slow, so using value parameterized tests in order to allow sharding.
 class Http2FrameHeaderTypeAndFlagTest
-    : public QuicheTestWithParam<std::tuple<Http2FrameType, Http2FrameFlag>> {
+    : public QuicheTestWithParam<std::tuple<Http2FrameType, uint8_t>> {
  protected:
   Http2FrameHeaderTypeAndFlagTest()
       : type_(std::get<0>(GetParam())), flags_(std::get<1>(GetParam())) {
@@ -161,7 +161,7 @@ class Http2FrameHeaderTypeAndFlagTest
   }
 
   const Http2FrameType type_;
-  const Http2FrameFlag flags_;
+  const uint8_t flags_;
 };
 
 class IsEndStreamTest : public Http2FrameHeaderTypeAndFlagTest {};


### PR DESCRIPTION
Since https://github.com/google/quiche/commit/5f86c8c3f812d83c8bb3aa8bb4c114033260dadb
listing tests with --gtest_list_tests prints non-UTF-8 characters.

For example, instead of:
  IsAck/0  # GetParam() = (DATA, 255)
invalid character is printed at the place of 255.

This patch changes the type of test parameter to uint8_t which is
correct for Http2FrameFlag combinations. |flags_| member is used to
initialize Http2FrameHeader which also expects uint8_t flags in its
constructor.