### PR TITLE
Allow setting a delay to backend responses

### DIFF
--- a/quiche/quic/tools/quic_backend_response.h
+++ b/quiche/quic/tools/quic_backend_response.h
@@ -89,7 +89,7 @@ class QuicBackendResponse {
   spdy::Http2HeaderBlock headers_;
   spdy::Http2HeaderBlock trailers_;
   std::string body_;
-  int delay_;
+  int delay_ = 0;
 };
 
 }  // namespace quic

--- a/quiche/quic/tools/quic_backend_response.h
+++ b/quiche/quic/tools/quic_backend_response.h
@@ -6,7 +6,6 @@
 #define QUICHE_QUIC_TOOLS_QUIC_BACKEND_RESPONSE_H_
 
 #include "absl/strings/string_view.h"
-#include "base/time/time.h"
 #include "quiche/quic/tools/quic_url.h"
 #include "quiche/spdy/core/http2_header_block.h"
 #include "quiche/spdy/core/spdy_protocol.h"
@@ -58,7 +57,7 @@ class QuicBackendResponse {
   const spdy::Http2HeaderBlock& headers() const { return headers_; }
   const spdy::Http2HeaderBlock& trailers() const { return trailers_; }
   const absl::string_view body() const { return absl::string_view(body_); }
-  base::TimeDelta delay() const { return delay_; }
+  int delay() const { return delay_; }
 
   void AddEarlyHints(const spdy::Http2HeaderBlock& headers) {
     spdy::Http2HeaderBlock hints = headers.Clone();
@@ -80,7 +79,7 @@ class QuicBackendResponse {
     body_.assign(body.data(), body.size());
   }
 
-  void set_delay(base::TimeDelta delay) {
+  void set_delay(int delay) {
     delay_ = delay;
   }
 
@@ -90,7 +89,7 @@ class QuicBackendResponse {
   spdy::Http2HeaderBlock headers_;
   spdy::Http2HeaderBlock trailers_;
   std::string body_;
-  base::TimeDelta delay_;
+  int delay_;
 };
 
 }  // namespace quic

--- a/quiche/quic/tools/quic_backend_response.h
+++ b/quiche/quic/tools/quic_backend_response.h
@@ -6,6 +6,7 @@
 #define QUICHE_QUIC_TOOLS_QUIC_BACKEND_RESPONSE_H_
 
 #include "absl/strings/string_view.h"
+#include "base/time/time.h"
 #include "quiche/quic/tools/quic_url.h"
 #include "quiche/spdy/core/http2_header_block.h"
 #include "quiche/spdy/core/spdy_protocol.h"
@@ -57,6 +58,7 @@ class QuicBackendResponse {
   const spdy::Http2HeaderBlock& headers() const { return headers_; }
   const spdy::Http2HeaderBlock& trailers() const { return trailers_; }
   const absl::string_view body() const { return absl::string_view(body_); }
+  base::TimeDelta delay() const { return delay_; }
 
   void AddEarlyHints(const spdy::Http2HeaderBlock& headers) {
     spdy::Http2HeaderBlock hints = headers.Clone();
@@ -78,12 +80,17 @@ class QuicBackendResponse {
     body_.assign(body.data(), body.size());
   }
 
+  void set_delay(base::TimeDelta delay) {
+    delay_ = delay;
+  }
+
  private:
   std::vector<spdy::Http2HeaderBlock> early_hints_;
   SpecialResponseType response_type_;
   spdy::Http2HeaderBlock headers_;
   spdy::Http2HeaderBlock trailers_;
   std::string body_;
+  base::TimeDelta delay_;
 };
 
 }  // namespace quic

--- a/quiche/quic/tools/quic_memory_cache_backend.cc
+++ b/quiche/quic/tools/quic_memory_cache_backend.cc
@@ -359,8 +359,6 @@ void QuicMemoryCacheBackend::FetchResponseFromBackend(
       << "Fetching QUIC response from backend in-memory cache for url "
       << request_url;
 
-  std::this_thread::sleep_for(
-    std::chrono::milliseconds(quic_response->delay()));
   quic_stream->OnResponseBackendComplete(quic_response);
 }
 

--- a/quiche/quic/tools/quic_memory_cache_backend.cc
+++ b/quiche/quic/tools/quic_memory_cache_backend.cc
@@ -359,7 +359,8 @@ void QuicMemoryCacheBackend::FetchResponseFromBackend(
       << "Fetching QUIC response from backend in-memory cache for url "
       << request_url;
 
-  std::this_thread::sleep_for(std::chrono::milliseconds( quic_response->delay()));
+  std::this_thread::sleep_for(
+    std::chrono::milliseconds(quic_response->delay()));
   quic_stream->OnResponseBackendComplete(quic_response);
 }
 

--- a/quiche/quic/tools/quic_memory_cache_backend.h
+++ b/quiche/quic/tools/quic_memory_cache_backend.h
@@ -12,7 +12,6 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
-#include "base/time/time.h"
 #include "quiche/quic/core/http/spdy_utils.h"
 #include "quiche/quic/platform/api/quic_mutex.h"
 #include "quiche/quic/tools/quic_backend_response.h"
@@ -153,7 +152,7 @@ class QuicMemoryCacheBackend : public QuicSimpleServerBackend {
   bool SupportsWebTransport() override { return enable_webtransport_; }
   void SetResponseDelay(absl::string_view host,
                                       absl::string_view path,
-                                      base::TimeDelta delay_millis);
+                                      int delay_millis);
 
  private:
   void AddResponseImpl(absl::string_view host, absl::string_view path,

--- a/quiche/quic/tools/quic_memory_cache_backend.h
+++ b/quiche/quic/tools/quic_memory_cache_backend.h
@@ -12,6 +12,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
+#include "base/time/time.h"
 #include "quiche/quic/core/http/spdy_utils.h"
 #include "quiche/quic/platform/api/quic_mutex.h"
 #include "quiche/quic/tools/quic_backend_response.h"
@@ -150,6 +151,9 @@ class QuicMemoryCacheBackend : public QuicSimpleServerBackend {
       const spdy::Http2HeaderBlock& request_headers,
       WebTransportSession* session) override;
   bool SupportsWebTransport() override { return enable_webtransport_; }
+  void SetResponseDelay(absl::string_view host,
+                                      absl::string_view path,
+                                      base::TimeDelta delay_millis);
 
  private:
   void AddResponseImpl(absl::string_view host, absl::string_view path,

--- a/quiche/quic/tools/quic_memory_cache_backend.h
+++ b/quiche/quic/tools/quic_memory_cache_backend.h
@@ -151,8 +151,8 @@ class QuicMemoryCacheBackend : public QuicSimpleServerBackend {
       WebTransportSession* session) override;
   bool SupportsWebTransport() override { return enable_webtransport_; }
   void SetResponseDelay(absl::string_view host,
-                                      absl::string_view path,
-                                      int delay_millis);
+                        absl::string_view path,
+                        int delay_millis);
 
  private:
   void AddResponseImpl(absl::string_view host, absl::string_view path,

--- a/quiche/quic/tools/quic_simple_server_stream.cc
+++ b/quiche/quic/tools/quic_simple_server_stream.cc
@@ -15,6 +15,7 @@
 #include "quiche/quic/core/http/quic_spdy_stream.h"
 #include "quiche/quic/core/http/spdy_utils.h"
 #include "quiche/quic/core/http/web_transport_http3.h"
+#include "quiche/quic/core/quic_alarm.h"
 #include "quiche/quic/core/quic_error_codes.h"
 #include "quiche/quic/core/quic_utils.h"
 #include "quiche/quic/platform/api/quic_bug_tracker.h"
@@ -245,6 +246,27 @@ std::string QuicSimpleServerStream::peer_host() const {
   return spdy_session()->peer_address().host().ToString();
 }
 
+class DelayedResponse : public QuicAlarm::DelegateWithContext {
+public:
+  DelayedResponse(QuicSimpleServerStream* stream, const QuicBackendResponse* response)
+    : QuicAlarm::DelegateWithContext(stream->spdy_session()->connection()->context())
+    , stream_(stream)
+    , response_(response) {
+    stream_ = stream;
+    response_ = response;
+  }
+
+  ~DelayedResponse() override = default;
+
+  void OnAlarm() override {
+    stream_->Respond(response_);
+  }
+
+  private:
+    QuicSimpleServerStream* stream_;
+    const QuicBackendResponse* response_;
+};
+
 void QuicSimpleServerStream::OnResponseBackendComplete(
     const QuicBackendResponse* response) {
   if (response == nullptr) {
@@ -253,6 +275,18 @@ void QuicSimpleServerStream::OnResponseBackendComplete(
     return;
   }
 
+  auto delay = response->delay();
+  if (!delay) {
+    Respond(response);
+    return;
+  }
+
+  auto* connection = session()->connection();
+  delayed_response_alarm_.reset(connection->alarm_factory()->CreateAlarm(new DelayedResponse(this, response)));
+  delayed_response_alarm_->Set(connection->clock()->Now() + QuicTime::Delta::FromMilliseconds(response->delay()));
+}
+
+void QuicSimpleServerStream::Respond(const QuicBackendResponse* response) {
   // Send Early Hints first.
   for (const auto& headers : response->early_hints()) {
     QUIC_DVLOG(1) << "Stream " << id() << " sending an Early Hints response: "

--- a/quiche/quic/tools/quic_simple_server_stream.h
+++ b/quiche/quic/tools/quic_simple_server_stream.h
@@ -61,6 +61,8 @@ class QuicSimpleServerStream : public QuicSpdyServerStreamBase,
   void SendStreamData(absl::string_view data, bool close_stream) override;
   void TerminateStreamWithError(QuicResetStreamError error) override;
 
+  void Respond(const QuicBackendResponse* response);
+
  protected:
   // Handles fresh body data whenever received when method is CONNECT.
   void HandleRequestConnectData(bool fin_received);
@@ -119,6 +121,7 @@ class QuicSimpleServerStream : public QuicSpdyServerStreamBase,
   bool response_sent_ = false;
 
   QuicSimpleServerBackend* quic_simple_server_backend_;  // Not owned.
+  std::unique_ptr<QuicAlarm> delayed_response_alarm_;
 };
 
 }  // namespace quic


### PR DESCRIPTION
This allows testing that timing the response receives correct values.

See https://chromium-review.googlesource.com/c/chromium/src/+/3815441
Bug: 1044264