### PR TITLE
No round robin for streams with the same priority

### DIFF
--- a/quiche/quic/core/quic_write_blocked_list.cc
+++ b/quiche/quic/core/quic_write_blocked_list.cc
@@ -108,8 +108,8 @@ void QuicWriteBlockedList::AddStream(QuicStreamId stream_id) {
   }
 
   bool push_front =
-      stream_id == batch_write_stream_id_[last_priority_popped_] &&
-      bytes_left_for_batch_write_[last_priority_popped_] > 0;
+      stream_id == batch_write_stream_id_[last_priority_popped_];
+
   priority_write_scheduler_.MarkStreamReady(stream_id, push_front);
 }
 


### PR DESCRIPTION
- Change behavior of QuicWriteBlockedList::AddStream() to avoid round robin. Previously the stream was be pushed to the end, if the soft limit for batched writing was exceeded. This caused, that other streams with the same priority were let to write at the next writing opportunity, instead of the stream that is being added. However, this is not what RFC 9218 suggests, unless "incremental" parameter is provided (which is not supported at the moment).
- This PR does not remove "batch_write_stream_id_" which is unnecessary (but it could)
- Issue #25 