### PR TITLE
Dont call virtual method `GetStatelessResetToken`  in ctor QuicSession::QuicSession

### DIFF
--- a/quiche/quic/core/quic_session.cc
+++ b/quiche/quic/core/quic_session.cc
@@ -111,10 +111,6 @@ QuicSession::QuicSession(
   closed_streams_clean_up_alarm_ =
       absl::WrapUnique<QuicAlarm>(connection_->alarm_factory()->CreateAlarm(
           new ClosedStreamsCleanUpDelegate(this)));
-  if (perspective() == Perspective::IS_SERVER &&
-      connection_->version().handshake_protocol == PROTOCOL_TLS1_3) {
-    config_.SetStatelessResetTokenToSend(GetStatelessResetToken());
-  }
   if (VersionHasIetfQuicFrames(transport_version())) {
     config_.SetMaxUnidirectionalStreamsToSend(
         config_.GetMaxUnidirectionalStreamsToSend() +
@@ -123,6 +119,11 @@ QuicSession::QuicSession(
 }
 
 void QuicSession::Initialize() {
+  if (perspective() == Perspective::IS_SERVER &&
+      connection_->version().handshake_protocol == PROTOCOL_TLS1_3) {
+    config_.SetStatelessResetTokenToSend(GetStatelessResetToken());
+  }
+
   connection_->set_visitor(this);
   connection_->SetSessionNotifier(this);
   connection_->SetDataProducer(this);


### PR DESCRIPTION
QuicSession class calls the virtual method GetStatelessResetToken() token in constructor

- Virtual methods should not be called in constructors, as the virtual call mechanism is disabled.
  This might lead to a wrong tokens being returned.