### PR TITLE
Change WakeUp in LibeventQuicEventLoop

### DIFF
--- a/quiche/quic/bindings/quic_libevent.cc
+++ b/quiche/quic/bindings/quic_libevent.cc
@@ -118,7 +118,11 @@ void LibeventQuicEventLoop::RunEventLoopOnce(QuicTime::Delta default_timeout) {
   event_base_loop(base_, EVLOOP_ONCE);
 }
 
-void LibeventQuicEventLoop::WakeUp() { event_base_loopbreak(base_); }
+void LibeventQuicEventLoop::WakeUp() { 
+  timeval timeout =
+      absl::ToTimeval(absl::Microseconds(0));
+  event_base_loopexit(base_, &timeout);
+}
 
 LibeventQuicEventLoop::Registration::Registration(
     LibeventQuicEventLoop* loop, QuicUdpSocketFd fd, QuicSocketEventMask events,


### PR DESCRIPTION
The previous event_base_loopbreak(base_);  did not work reliably.  The reason is that exits the loop only during `event_base_loop(base_, EVLOOP_ONCE);` . Since the requested break is reset at the beginning of the loop https://github.com/libevent/libevent/blob/1af745d033678333752afcd8724f5d6351561b4e/event.c#L2000 . Using `event_base_loopexit` is also remembered if the call from another thread occurs during the phase outside of `event_base_loop`. It would be nice if this chnage/fix can go into libquiche.