### PR TITLE
Exclude poll event loop, if libevent is enabled

### DIFF
--- a/quiche/quic/core/io/quic_default_event_loop.cc
+++ b/quiche/quic/core/io/quic_default_event_loop.cc
@@ -6,7 +6,9 @@
 
 #include <memory>
 
+#ifndef QUICHE_ENABLE_LIBEVENT
 #include "quiche/quic/core/io/quic_poll_event_loop.h"
+#endif
 #include "quiche/common/platform/api/quiche_event_loop.h"
 
 #ifdef QUICHE_ENABLE_LIBEVENT


### PR DESCRIPTION
This change is necessary for windows, which does not support poll.h