### PR TITLE
fix: build error on linux

### DIFF
--- a/quiche/common/wire_serialization.h
+++ b/quiche/common/wire_serialization.h
@@ -390,7 +390,7 @@ absl::StatusOr<QuicheBuffer> SerializeIntoBuffer(
     return absl::InternalError(absl::StrCat(
         "Excess ", writer.remaining(), " bytes allocated while serializing"));
   }
-  return buffer;
+  return std::move(buffer);
 }
 
 }  // namespace quiche


### PR DESCRIPTION
build command: bazel build //quiche:quiche_core
error message: ./quiche/common/wire_serialization.h:393:10: error: could not convert 'buffer' from 'quiche::QuicheBuffer' to 'absl::StatusOr<quiche::QuicheBuffer>' Target //quiche:quiche_core failed to build