### PR TITLE
Add FuzzTest set up and OSS-Fuzz integration

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -74,6 +74,13 @@ http_archive(
     urls = ["https://github.com/google/re2/archive/03da4fc0857c285e3a26782f6bc8931c4c950df4.zip"],
 )
 
+http_archive(
+    name = "com_google_fuzztest",
+    sha256 = "c75f224b34c3c62ee901381fb743f6326f7b91caae0ceb8fe62f3fd36f187627",
+    strip_prefix = "fuzztest-58b4e7065924f1a284952b84ea827ce35a87e4dc",
+    urls = ["https://github.com/google/fuzztest/archive/58b4e7065924f1a284952b84ea827ce35a87e4dc.zip"],
+)
+
 # -------- Load and call dependencies of underlying libraries --------
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")

--- a/quiche/BUILD.bazel
+++ b/quiche/BUILD.bazel
@@ -322,6 +322,31 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "http_frame_fuzzer",
+    srcs = ["http2/decoder/http2_frame_decoder_test.cc"],
+    deps = [
+        ":binary_http",
+        ":quiche_core",
+        ":quiche_platform_default_testonly",
+        ":quiche_protobufs_testonly_cc_proto",
+        ":quiche_tool_support",
+        ":quiche_test_support",
+        "@boringssl//:crypto",
+        "@boringssl//:ssl",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:optional",
+        "@com_google_fuzztest//fuzztest",
+        "@com_google_fuzztest//fuzztest:fuzztest_gtest_main",
+        "@com_google_googleurl//url",
+    ],
+)
+
 test_suite_from_source_list(
     name = "quiche_tests",
     srcs = quiche_tests_srcs,
@@ -354,6 +379,7 @@ test_suite_from_source_list(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
+        "@com_google_fuzztest//fuzztest",
         "@com_google_googletest//:gtest_main",
         "@com_google_googleurl//url",
     ],

--- a/quiche/http2/decoder/http2_frame_decoder_test.cc
+++ b/quiche/http2/decoder/http2_frame_decoder_test.cc
@@ -18,6 +18,8 @@
 #include "quiche/http2/test_tools/verify_macros.h"
 #include "quiche/common/platform/api/quiche_logging.h"
 
+#include "fuzztest/fuzztest.h"
+
 using ::testing::AssertionSuccess;
 
 namespace http2 {
@@ -913,6 +915,14 @@ TEST_F(Http2FrameDecoderTest, WindowUpdateTooLong) {
   Http2FrameHeader header(5, Http2FrameType::WINDOW_UPDATE, 0, 1);
   EXPECT_TRUE(DecodePayloadExpectingFrameSizeError(kFrameData, header));
 }
+
+void FuzzFrameDecoder(const std::string &s) {
+    http2::Http2FrameDecoderNoOpListener listener;
+    http2::Http2FrameDecoder decoder(&listener);
+    http2::DecodeBuffer db(reinterpret_cast<const char *>(s.c_str()), s.size());
+    decoder.DecodeFrame(&db);
+}
+FUZZ_TEST(Http2FrameDecoderFuzzTest, FuzzFrameDecoder);
 
 }  // namespace
 }  // namespace test


### PR DESCRIPTION
Adds a fuzzer using the FuzzTest framework https://github.com/google/fuzztest

The fuzzer is a migration of https://github.com/google/quiche/commit/8294639c8d09a3754d5ff214a69614848bd6e1e7 to the fuzztest set up.

Recently, Quiche was integrated into OSS-Fuzz  https://github.com/google/oss-fuzz/tree/master/projects/quiche It would be great to set it up so the OSS-Fuzz integration uses the fuzzers directly from Quiche, and set it up so whenever new fuzzers are added in Quiche then these will be automatically picked up by OSS-Fuzz. Integrating with FuzzTest will make this a smooth process as OSS-Fuzz already has support for FuzzTest. We can also migrate the other fuzzer https://github.com/google/quiche/commit/31bbf1dd490d131870e2435a660b4d3b4f6d51bb recently added.

If you'd like to integrate with OSS-Fuzz, would it be possible to get a list of maintainer emails that I can put as CC in the `project.yaml` on OSS-Fuzz? https://github.com/google/oss-fuzz/blob/master/projects/quiche/project.yaml