### PR TITLE
Initialize socket_factory_ to nullptr

### DIFF
--- a/quiche/quic/tools/connect_tunnel.h
+++ b/quiche/quic/tools/connect_tunnel.h
@@ -73,7 +73,7 @@ class ConnectTunnel : public ConnectingClientSocket::AsyncVisitor {
           QuicResetStreamError::FromIetf(QuicHttp3ErrorCode::CONNECT_ERROR));
 
   const absl::flat_hash_set<QuicServerId> acceptable_destinations_;
-  SocketFactory* const socket_factory_;
+  SocketFactory* const socket_factory_ = nullptr;
 
   // Null when client stream closed.
   QuicSimpleServerBackend::RequestHandler* client_stream_request_handler_;

--- a/quiche/quic/tools/connect_udp_tunnel.h
+++ b/quiche/quic/tools/connect_udp_tunnel.h
@@ -81,7 +81,7 @@ class ConnectUdpTunnel : public ConnectingClientSocket::AsyncVisitor,
                              QuicResetStreamError error_code);
 
   const absl::flat_hash_set<QuicServerId> acceptable_targets_;
-  SocketFactory* const socket_factory_;
+  SocketFactory* const socket_factory_ = nullptr;
   const std::string server_label_;
 
   // Null when client stream closed.


### PR DESCRIPTION
This fixes a segfault when trying to use `--connect-proxy-destinations`, replacing it with a DCHECK error.

I wasn't able to figure out how to actually get this functionality operating, in the short amount of time I had to try. But this at least fixes the segfault.