### PR TITLE
Handle zombie streams, when sending rst

### DIFF
--- a/quiche/quic/core/quic_stream.cc
+++ b/quiche/quic/core/quic_stream.cc
@@ -891,6 +891,9 @@ void QuicStream::MaybeSendRstStream(QuicResetStreamError error) {
   session()->MaybeSendRstStreamFrame(id(), error, stream_bytes_written());
   rst_sent_ = true;
   CloseWriteSide();
+  if (read_side_closed_ && write_side_closed_ && !IsWaitingForAcks()) {
+    session_->MaybeCloseZombieStream(id_);
+  }
 }
 
 bool QuicStream::HasBufferedData() const {


### PR DESCRIPTION
If QuicSession::OnStreamClosed is called on a stream with a pending outgoing fin, a zombie stream will be created. A call to QuicStream::OnStopSending afterward, which in turn calls  QuicStream::MaybeSendRstStream should kill the zombie finally. But this route misses a call to session's session_->MaybeCloseZombieStream, so the stream is not removed from active streams.  This triggers a quic_bug_12435_2 when OnConnectionClosed is finally called on session close. This commit adds the missing call to the MaybeCloseZombieStream.