### PR TITLE
bugfix: Don't overwrite early address validation tokens

### DIFF
--- a/quiche/quic/core/crypto/quic_client_session_cache.h
+++ b/quiche/quic/core/crypto/quic_client_session_cache.h
@@ -70,11 +70,17 @@ class QUICHE_EXPORT QuicClientSessionCache : public SessionCache {
     std::string token;  // An opaque string received in NEW_TOKEN frame.
   };
 
+  // Creates a dummy entry that only contains a token and insert into |cache_|
+  void CreateAndInsertTokenDummy(
+	  const QuicServerId& server_id,
+	  const absl::string_view& token);
+
   // Creates a new entry and insert into |cache_|.
   void CreateAndInsertEntry(const QuicServerId& server_id,
                             bssl::UniquePtr<SSL_SESSION> session,
                             const TransportParameters& params,
-                            const ApplicationState* application_state);
+                            const ApplicationState* application_state,
+                            const std::string &token = std::string());
 
   QuicLRUCache<std::string, Entry, absl::Hash<std::string>> cache_;
 };


### PR DESCRIPTION
Hi everyone,
I was working with chromium connecting to a QUIC server using cloudflare quiche (with an address validation token handling routine, hopefully soon to be added to that library) as the QUIC implementation when I encountered the problem described in issue #54. 

Essentially what this PR does, is when a new TLS session ticket arrives, it checks if an address validation token is already present within the cache. If so, it copies it into the new entry. When a new address validation token arrives and we have no cache entry for the corresponding server, it creates a dummy entry only containing the AV token without any session information stored, which can be inserted at a later time when the TLS ticket arrives.

This solves the problem that AV tokens do not get used in subsequent connections when they arrive "too early" i.e. before the TLS session ticket from issue #54.
