### PR TITLE
Add API_VERSION guard around QUIC client support for Trust Anchor IDs

### DIFF
--- a/quiche/quic/core/crypto/tls_server_connection.cc
+++ b/quiche/quic/core/crypto/tls_server_connection.cc
@@ -76,6 +76,7 @@ absl::Status TlsServerConnection::ConfigureSSL(
 void TlsServerConnection::SetCertChain(
     const std::vector<CRYPTO_BUFFER*>& cert_chain,
     const std::string& trust_anchor_id) {
+#if defined(BORINGSSL_API_VERSION) && BORINGSSL_API_VERSION >= 32
   if (GetQuicReloadableFlag(enable_tls_trust_anchor_ids)) {
     QUIC_RELOADABLE_FLAG_COUNT_N(enable_tls_trust_anchor_ids, 1, 2);
     bssl::UniquePtr<SSL_CREDENTIAL> credential(SSL_CREDENTIAL_new_x509());
@@ -100,6 +101,10 @@ void TlsServerConnection::SetCertChain(
     (void)trust_anchor_id;  // Suppress unused parameter error.
 #endif
     SSL_add1_credential(ssl(), credential.get());
+#else
+  (void)trust_anchor_id;  // Suppress unused parameter error.
+  if (false) {
+#endif
   } else {
     SSL_set_chain_and_key(ssl(), cert_chain.data(), cert_chain.size(), nullptr,
                           &TlsServerConnection::kPrivateKeyMethod);


### PR DESCRIPTION
Add more version guards around Trust Anchor IDs when these APIs got
introduced in BORINGSSL. This helps to build latest envoy with an
alternative boringssl fork.

And also in many cases this might be undesirable. Also pondring if
this guard should be just >= 36 anyway.
