### PR TITLE
Safeguard interim header callbacks for unregistered handlers

### DIFF
--- a/quiche/quic/core/http/quic_spdy_client_stream_test.cc
+++ b/quiche/quic/core/http/quic_spdy_client_stream_test.cc
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "absl/strings/str_cat.h"
 #include "quiche/quic/core/crypto/null_encrypter.h"
@@ -20,6 +21,7 @@
 #include "quiche/quic/test_tools/crypto_test_utils.h"
 #include "quiche/quic/test_tools/quic_spdy_session_peer.h"
 #include "quiche/quic/test_tools/quic_test_utils.h"
+#include "quiche/quic/tools/quic_simple_client_session.h"
 #include "quiche/common/simple_buffer_allocator.h"
 
 using quiche::HttpHeaderBlock;
@@ -50,6 +52,23 @@ class MockQuicSpdyClientSession : public QuicSpdyClientSession {
               (const QuicFrame& frame, TransmissionType type), (override));
 
   using QuicSession::ActivateStream;
+
+ private:
+  QuicCryptoClientConfig crypto_config_;
+};
+
+class TestQuicSimpleClientSession : public QuicSimpleClientSession {
+ public:
+  TestQuicSimpleClientSession(
+      const ParsedQuicVersionVector& supported_versions,
+      QuicConnection* connection)
+      : QuicSimpleClientSession(DefaultQuicConfig(), supported_versions,
+                                connection, /*network_helper=*/nullptr,
+                                QuicServerId("example.com", 443),
+                                &crypto_config_,
+                                /*drop_response_body=*/false,
+                                /*enable_web_transport=*/false),
+        crypto_config_(crypto_test_utils::ProofVerifierForTesting()) {}
 
  private:
   QuicCryptoClientConfig crypto_config_;
@@ -309,6 +328,68 @@ TEST_P(QuicSpdyClientStreamTest, TestReceiving101) {
                               headers);
   EXPECT_THAT(stream_->stream_error(),
               IsStreamError(QUIC_BAD_APPLICATION_PAYLOAD));
+}
+
+TEST_P(QuicSpdyClientStreamTest,
+       InterimResponseWithoutCallbackDoesNotCrashSimpleClient) {
+  TestQuicSimpleClientSession simple_session(connection_->supported_versions(),
+                                             connection_);
+  simple_session.Initialize();
+  auto* simple_stream = static_cast<QuicSpdyClientStream*>(
+      simple_session.CreateOutgoingBidirectionalStream());
+  ASSERT_NE(simple_stream, nullptr);
+
+  headers_[":status"] = "129";
+  auto headers = AsHeaderList(headers_);
+  simple_stream->OnStreamHeaderList(false, headers.uncompressed_header_bytes(),
+                                    headers);
+
+  EXPECT_EQ(129, simple_stream->response_code());
+  ASSERT_EQ(simple_stream->preliminary_headers().size(), 1);
+  EXPECT_EQ("129",
+            simple_stream->preliminary_headers()
+                .front()
+                .find(":status")
+                ->second);
+  EXPECT_THAT(simple_stream->stream_error(), IsQuicStreamNoError());
+}
+
+TEST_P(QuicSpdyClientStreamTest,
+       InterimResponseCallbackUsesLatestSessionHandler) {
+  TestQuicSimpleClientSession simple_session(connection_->supported_versions(),
+                                             connection_);
+  simple_session.Initialize();
+  auto* simple_stream = static_cast<QuicSpdyClientStream*>(
+      simple_session.CreateOutgoingBidirectionalStream());
+  ASSERT_NE(simple_stream, nullptr);
+
+  std::vector<std::string> statuses;
+  simple_session.set_on_interim_headers(
+      [&statuses](const HttpHeaderBlock& headers) {
+        statuses.push_back(std::string(headers.find(":status")->second));
+      });
+
+  headers_[":status"] = "103";
+  auto headers = AsHeaderList(headers_);
+  simple_stream->OnStreamHeaderList(false, headers.uncompressed_header_bytes(),
+                                    headers);
+
+  simple_session.set_on_interim_headers(
+      quiche::MultiUseCallback<void(const HttpHeaderBlock&)>());
+  headers_[":status"] = "199";
+  headers = AsHeaderList(headers_);
+  simple_stream->OnStreamHeaderList(false, headers.uncompressed_header_bytes(),
+                                    headers);
+
+  EXPECT_THAT(statuses, ElementsAre("103"));
+  ASSERT_EQ(simple_stream->preliminary_headers().size(), 2);
+  EXPECT_EQ("103",
+            simple_stream->preliminary_headers()
+                .front()
+                .find(":status")
+                ->second);
+  EXPECT_EQ("199",
+            simple_stream->preliminary_headers().back().find(":status")->second);
 }
 
 TEST_P(QuicSpdyClientStreamTest, TestFramingOnePacket) {

--- a/quiche/quic/tools/quic_simple_client_session.cc
+++ b/quiche/quic/tools/quic_simple_client_session.cc
@@ -63,9 +63,16 @@ QuicSimpleClientSession::CreateClientStream() {
       drop_response_body_);
   stream->set_on_interim_headers(
       [this](const quiche::HttpHeaderBlock& headers) {
-        on_interim_headers_(headers);
+        MaybeNotifyInterimHeaders(headers);
       });
   return stream;
+}
+
+void QuicSimpleClientSession::MaybeNotifyInterimHeaders(
+    const quiche::HttpHeaderBlock& headers) {
+  if (on_interim_headers_) {
+    on_interim_headers_(headers);
+  }
 }
 
 WebTransportHttp3VersionSet

--- a/quiche/quic/tools/quic_simple_client_session.h
+++ b/quiche/quic/tools/quic_simple_client_session.h
@@ -64,6 +64,8 @@ class QuicSimpleClientSession : public QuicSpdyClientSession {
   }
 
  private:
+  void MaybeNotifyInterimHeaders(const quiche::HttpHeaderBlock& headers);
+
   quiche::MultiUseCallback<void(const quiche::HttpHeaderBlock&)>
       on_interim_headers_;
   QuicClientBase::NetworkHelper* network_helper_;


### PR DESCRIPTION
Summary:
This fixes a crash in the simple QUIC client when it receives a valid interim `1xx` response and no interim-header callback has been registered. The crash happened because `QuicSimpleClientSession` always installed a stream callback, but that callback unconditionally invoked an empty session-level `MultiUseCallback`. The fix routes interim-header delivery through a guarded session helper so missing callbacks become a no-op, while preserving the existing late-binding behavior for streams that were created before a callback is registered.

Changes:
- `quiche/quic/tools/quic_simple_client_session.h`
  - Added a private `MaybeNotifyInterimHeaders(const quiche::HttpHeaderBlock&)` helper declaration.
- `quiche/quic/tools/quic_simple_client_session.cc`
  - Changed `CreateClientStream()` to forward interim headers through `MaybeNotifyInterimHeaders(...)` instead of directly invoking `on_interim_headers_`.
  - Added a null check in `MaybeNotifyInterimHeaders(...)` before invoking the session callback.
- `quiche/quic/core/http/quic_spdy_client_stream_test.cc`
  - Added `TestQuicSimpleClientSession` test scaffolding for exercising the simple-client path.
  - Added `InterimResponseWithoutCallbackDoesNotCrashSimpleClient` to verify a valid `1xx` response is stored without crashing when no callback is registered.
  - Added `InterimResponseCallbackUsesLatestSessionHandler` to verify late callback registration still works and clearing the callback stops further notifications without affecting interim-header storage.

Testing:
- Run:
  - `git diff --check`
  - `/home/kedar/.cache/bazelisk/downloads/sha256/7ff2b6a675b59a791d007c526977d5262ade8fa52efc8e0d1ff9e18859909fc0/bin/bazel --output_base=/tmp/quiche-bazel-out --install_base=/tmp/quiche-bazel-install test //quiche:quic_spdy_client_stream_test`
- New test names:
  - `InterimResponseWithoutCallbackDoesNotCrashSimpleClient`
  - `InterimResponseCallbackUsesLatestSessionHandler`

Closes #103