### PR TITLE
Reject client-side receipt of server Initial packets with non-zero Token Length (RFC 9000 §17.2.2)

### DIFF
--- a/quiche/quic/core/quic_connection.cc
+++ b/quiche/quic/core/quic_connection.cc
@@ -1059,6 +1059,17 @@ bool QuicConnection::OnUnauthenticatedPublicHeader(
     framer_.set_drop_incoming_retry_packets(true);
   }
 
+  // RFC 9000, Section 17.2.2: a client MUST discard, or MAY close the
+  // connection on, a server Initial packet that carries a non-zero-length
+  // Token field, since only clients are permitted to send Initial tokens.
+  if (perspective_ == Perspective::IS_CLIENT && header.version_flag &&
+      header.long_packet_type == INITIAL && !header.retry_token.empty()) {
+    CloseConnection(IETF_QUIC_PROTOCOL_VIOLATION,
+                     "Server Initial packet has non-zero token length",
+                     ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
+    return false;
+  }
+
   if (!ValidateServerConnectionId(header)) {
     ++stats_.packets_dropped;
     QuicConnectionId server_connection_id =

--- a/quiche/quic/core/quic_connection_test.cc
+++ b/quiche/quic/core/quic_connection_test.cc
@@ -18335,6 +18335,42 @@ TEST_P(QuicConnectionTest, ResetStreamAt) {
   connection_.OnResetStreamAtFrame(QuicResetStreamAtFrame(0, 0, 0, 20, 10));
 }
 
+// Regression test for https://github.com/google/quiche/issues/138.
+// RFC 9000, Section 17.2.2 requires a client to reject (or discard) a server
+// Initial packet that carries a non-zero-length Token field, since only
+// clients are permitted to send Initial tokens.
+TEST_P(QuicConnectionTest, ClientRejectsServerInitialWithNonZeroTokenLength) {
+  if (!VersionIsIetfQuic(connection_.transport_version())) {
+    return;
+  }
+  ASSERT_EQ(Perspective::IS_CLIENT, connection_.perspective());
+
+  QuicPacketHeader header;
+  header.destination_connection_id = connection_id_;
+  header.version_flag = true;
+  header.long_packet_type = INITIAL;
+  header.retry_token_length_length = quiche::VARIABLE_LENGTH_INTEGER_LENGTH_1;
+  header.retry_token = absl::string_view("\x01", 1);
+  header.length_length = quiche::VARIABLE_LENGTH_INTEGER_LENGTH_2;
+  header.packet_number = QuicPacketNumber(1);
+
+  QuicFrames frames;
+  frames.push_back(QuicFrame(&crypto_frame_));
+  std::unique_ptr<QuicPacket> packet(ConstructPacket(header, frames));
+  char buffer[kMaxOutgoingPacketSize];
+  size_t encrypted_length =
+      peer_framer_.EncryptPayload(ENCRYPTION_INITIAL, QuicPacketNumber(1),
+                                  *packet, buffer, kMaxOutgoingPacketSize);
+
+  EXPECT_CALL(visitor_, OnConnectionClosed(_, _)).Times(1);
+  connection_.ProcessUdpPacket(
+      kSelfAddress, kPeerAddress,
+      QuicReceivedPacket(buffer, encrypted_length, clock_.ApproximateNow(),
+                         false));
+  EXPECT_FALSE(connection_.connected());
+  TestConnectionCloseQuicErrorCode(IETF_QUIC_PROTOCOL_VIOLATION);
+}
+
 TEST_P(QuicConnectionTest, OnParsedClientHelloInfoWithDebugVisitor) {
   const ParsedClientHello parsed_chlo{.sni = "sni",
                                       .uaid = "uiad",


### PR DESCRIPTION
# Reject client-side receipt of server Initial packets with non-zero Token Length

Fixes [google/quiche#138](https://github.com/google/quiche/issues/138)

## Problem

RFC 9000, Section 17.2.2 requires a client to discard, or MAY close the
connection on, an Initial packet from the server that carries a
non-zero-length Token field, since only clients are permitted to send
Initial tokens.

`quiche` parsed and stored `header.retry_token` but never checked for
this case on the client receive path. A server, or an on-path attacker
spoofing one, could send an Initial packet with a non-empty token and
the client would accept it.

## Fix

Added a check in `QuicConnection::OnUnauthenticatedPublicHeader()`
that closes the connection with `IETF_QUIC_PROTOCOL_VIOLATION` when a
client receives a server Initial packet with a non-empty retry token.

```cpp
if (perspective_ == Perspective::IS_CLIENT && header.version_flag &&
    header.long_packet_type == INITIAL && !header.retry_token.empty()) {
  CloseConnection(IETF_QUIC_PROTOCOL_VIOLATION,
                   "Server Initial packet has non-zero token length",
                   ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
  return false;
}
```

## Testing

Added `ClientRejectsServerInitialWithNonZeroTokenLength` to
`quic_connection_test.cc`. It constructs a server-perspective Initial
packet with a non-empty retry token, feeds it through
`ProcessUdpPacket`, and asserts the connection closes with
`IETF_QUIC_PROTOCOL_VIOLATION`.

```
bazel test //quiche:quic_connection_test \
  --test_filter='*ClientRejectsServerInitialWithNonZeroTokenLength*'
```

All 8 parameterized instances pass, including both gQUIC (short-circuited
by the existing `!IsIetfQuic()` check) and IETF QUIC versions.