### PR TITLE
Add an API to encode headers as HPACK never-indexed literals

### DIFF
--- a/quiche/http2/adapter/http2_adapter.h
+++ b/quiche/http2/adapter/http2_adapter.h
@@ -48,6 +48,23 @@ class QUICHE_EXPORT Http2Adapter {
   // Submits a PING on the connection.
   virtual void SubmitPing(Http2PingId ping_id) = 0;
 
+  // Sets a policy for deciding whether individual header fields should be
+  // encoded as HPACK "Literal Header Field Never Indexed" (RFC 7541 Section
+  // 6.2.3). Headers for which |policy| returns true are never inserted into
+  // the HPACK dynamic table and are encoded with the never-indexed literal
+  // representation, which also instructs downstream intermediaries not to
+  // index them. This is typically used for high-entropy header values (e.g.
+  // request IDs, trace IDs) that would churn the dynamic table without
+  // compression benefit, or for sensitive values. The policy applies to
+  // headers submitted after this call via SubmitRequest(), SubmitResponse()
+  // and SubmitTrailer(), and takes precedence over any other indexing
+  // behavior. Note that per RFC 7541 Section 6.2.3, the header *name* may
+  // still be represented by a table index; only the value is always emitted
+  // as a literal. When cookie crumbling is enabled, the policy may be
+  // evaluated once per cookie crumb. The default implementation ignores the
+  // policy; NgHttp2Adapter and OgHttp2Adapter both honor it.
+  virtual void SetNeverIndexingPolicy(NeverIndexingPolicy /*policy*/) {}
+
   // Starts a graceful shutdown. A no-op for clients.
   virtual void SubmitShutdownNotice() = 0;
 

--- a/quiche/http2/adapter/http2_protocol.h
+++ b/quiche/http2/adapter/http2_protocol.h
@@ -9,6 +9,7 @@
 #include "absl/base/attributes.h"
 #include "absl/strings/string_view.h"
 #include "quiche/common/platform/api/quiche_export.h"
+#include "quiche/common/quiche_callbacks.h"
 
 namespace http2 {
 namespace adapter {
@@ -32,6 +33,15 @@ std::pair<absl::string_view, bool> GetStringView(const HeaderRep& rep);
 // Represents an HTTP/2 header field. A header field is a key-value pair with
 // lowercase keys (as specified in RFC 7540 Section 8.1.2).
 using Header = std::pair<HeaderRep, HeaderRep>;
+
+// Decides whether a header field should be encoded as an HPACK "Literal
+// Header Field Never Indexed" (RFC 7541 Section 6.2.3). Returning true
+// prevents the field from being inserted into the HPACK dynamic table and
+// instructs intermediaries not to index it either. Typically used for
+// high-entropy header values (e.g. request IDs, trace IDs) that would churn
+// the dynamic table without compression benefit, or for sensitive values.
+using NeverIndexingPolicy = quiche::MultiUseCallback<bool(
+    absl::string_view name, absl::string_view value)>;
 
 // Represents an HTTP/2 SETTINGS key-value parameter.
 struct QUICHE_EXPORT Http2Setting {

--- a/quiche/http2/adapter/nghttp2_adapter.cc
+++ b/quiche/http2/adapter/nghttp2_adapter.cc
@@ -300,9 +300,13 @@ void NgHttp2Adapter::SubmitRst(Http2StreamId stream_id,
   }
 }
 
+void NgHttp2Adapter::SetNeverIndexingPolicy(NeverIndexingPolicy policy) {
+  never_indexing_policy_ = std::move(policy);
+}
+
 int32_t NgHttp2Adapter::SubmitRequest(absl::Span<const Header> headers,
                                       bool end_stream, void* stream_user_data) {
-  auto nvs = GetNghttp2Nvs(headers);
+  auto nvs = GetNghttp2Nvs(headers, &never_indexing_policy_);
   std::unique_ptr<nghttp2_data_provider> provider;
 
   if (!end_stream) {
@@ -323,7 +327,7 @@ int32_t NgHttp2Adapter::SubmitRequest(absl::Span<const Header> headers,
 int NgHttp2Adapter::SubmitResponse(Http2StreamId stream_id,
                                    absl::Span<const Header> headers,
                                    bool end_stream) {
-  auto nvs = GetNghttp2Nvs(headers);
+  auto nvs = GetNghttp2Nvs(headers, &never_indexing_policy_);
   std::unique_ptr<nghttp2_data_provider> provider;
   if (!end_stream) {
     provider = std::make_unique<nghttp2_data_provider>();
@@ -340,7 +344,7 @@ int NgHttp2Adapter::SubmitResponse(Http2StreamId stream_id,
 
 int NgHttp2Adapter::SubmitTrailer(Http2StreamId stream_id,
                                   absl::Span<const Header> trailers) {
-  auto nvs = GetNghttp2Nvs(trailers);
+  auto nvs = GetNghttp2Nvs(trailers, &never_indexing_policy_);
   int result = nghttp2_submit_trailer(session_->raw_ptr(), stream_id,
                                       nvs.data(), nvs.size());
   QUICHE_VLOG(1) << "Submitted trailers with " << nvs.size()

--- a/quiche/http2/adapter/nghttp2_adapter.h
+++ b/quiche/http2/adapter/nghttp2_adapter.h
@@ -43,6 +43,8 @@ class QUICHE_EXPORT NgHttp2Adapter : public Http2Adapter {
   // this method to originate PINGs. See nghttp2_option_set_no_auto_ping_ack().
   void SubmitPing(Http2PingId ping_id) override;
 
+  void SetNeverIndexingPolicy(NeverIndexingPolicy policy) override;
+
   void SubmitShutdownNotice() override;
   void SubmitGoAway(Http2StreamId last_accepted_stream_id,
                     Http2ErrorCode error_code,
@@ -136,6 +138,7 @@ class QUICHE_EXPORT NgHttp2Adapter : public Http2Adapter {
   Http2VisitorInterface& visitor_;
   const nghttp2_option* options_;
   Perspective perspective_;
+  NeverIndexingPolicy never_indexing_policy_;
 
   using MetadataSourceVec =
       absl::InlinedVector<std::unique_ptr<MetadataSource>, 2>;

--- a/quiche/http2/adapter/nghttp2_adapter_test.cc
+++ b/quiche/http2/adapter/nghttp2_adapter_test.cc
@@ -1,9 +1,11 @@
 #include "quiche/http2/adapter/nghttp2_adapter.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "absl/strings/string_view.h"
 #include "quiche/http2/adapter/http2_protocol.h"
 #include "quiche/http2/adapter/http2_visitor_interface.h"
 #include "quiche/http2/adapter/mock_http2_visitor.h"
@@ -2253,6 +2255,67 @@ TEST(NgHttp2AdapterTest, ClientRejects101Response) {
   EXPECT_EQ(0, result);
   EXPECT_THAT(visitor.data(), EqualsFrames({SpdyFrameType::SETTINGS,
                                             SpdyFrameType::RST_STREAM}));
+}
+
+TEST(NgHttp2AdapterTest, ClientSubmitRequestWithNeverIndexingPolicy) {
+  const std::vector<Header> headers =
+      ToHeaders({{":method", "GET"},
+                 {":scheme", "http"},
+                 {":authority", "example.com"},
+                 {":path", "/this/is/request/one"},
+                 {"x-request-id", "12345678-abcd"}});
+
+  TestVisitor visitor;
+  auto adapter = NgHttp2Adapter::CreateClientAdapter(visitor);
+  adapter->SetNeverIndexingPolicy(
+      [](absl::string_view name, absl::string_view /*value*/) {
+        return name == "x-request-id";
+      });
+
+  // A control adapter without the policy, submitting the same request.
+  TestVisitor control_visitor;
+  auto control_adapter = NgHttp2Adapter::CreateClientAdapter(control_visitor);
+
+  const int32_t stream_id = adapter->SubmitRequest(headers, true, nullptr);
+  ASSERT_GT(stream_id, 0);
+  const int32_t control_stream_id =
+      control_adapter->SubmitRequest(headers, true, nullptr);
+  ASSERT_EQ(stream_id, control_stream_id);
+
+  EXPECT_CALL(visitor, OnBeforeFrameSent(SETTINGS, 0, _, 0x0));
+  EXPECT_CALL(visitor, OnFrameSent(SETTINGS, 0, _, 0x0, 0));
+  EXPECT_CALL(visitor, OnBeforeFrameSent(HEADERS, stream_id, _, 0x5));
+  EXPECT_CALL(visitor, OnFrameSent(HEADERS, stream_id, _, 0x5, 0));
+  EXPECT_EQ(0, adapter->Send());
+
+  EXPECT_CALL(control_visitor, OnBeforeFrameSent(SETTINGS, 0, _, 0x0));
+  EXPECT_CALL(control_visitor, OnFrameSent(SETTINGS, 0, _, 0x0, 0));
+  EXPECT_CALL(control_visitor,
+              OnBeforeFrameSent(HEADERS, control_stream_id, _, 0x5));
+  EXPECT_CALL(control_visitor,
+              OnFrameSent(HEADERS, control_stream_id, _, 0x5, 0));
+  EXPECT_EQ(0, control_adapter->Send());
+
+  // The two encodings must be identical except for the representation prefix
+  // of the "x-request-id" field: never indexed (0b0001xxxx, RFC 7541 Section
+  // 6.2.3) with the policy, versus incremental indexing (0b01xxxxxx, Section
+  // 6.2.1) without it.
+  const absl::string_view data = visitor.data();
+  const absl::string_view control_data = control_visitor.data();
+  ASSERT_EQ(data.size(), control_data.size());
+  int diff_count = 0;
+  for (size_t i = 0; i < data.size(); ++i) {
+    if (data[i] != control_data[i]) {
+      ++diff_count;
+      EXPECT_EQ(0x10, static_cast<uint8_t>(data[i]) & 0xF0);
+      EXPECT_EQ(0x40, static_cast<uint8_t>(control_data[i]) & 0xC0);
+    }
+  }
+  EXPECT_EQ(1, diff_count);
+
+  // The never-indexed header was not inserted into the HPACK dynamic table.
+  EXPECT_LT(adapter->GetHpackEncoderDynamicTableSize(),
+            control_adapter->GetHpackEncoderDynamicTableSize());
 }
 
 TEST(NgHttp2AdapterTest, ClientSubmitRequest) {

--- a/quiche/http2/adapter/nghttp2_util.cc
+++ b/quiche/http2/adapter/nghttp2_util.cc
@@ -63,7 +63,9 @@ absl::string_view ToStringView(const uint8_t* pointer, size_t length) {
   return absl::string_view(reinterpret_cast<const char*>(pointer), length);
 }
 
-std::vector<nghttp2_nv> GetNghttp2Nvs(absl::Span<const Header> headers) {
+std::vector<nghttp2_nv> GetNghttp2Nvs(
+    absl::Span<const Header> headers,
+    const NeverIndexingPolicy* never_indexing_policy) {
   const int num_headers = headers.size();
   std::vector<nghttp2_nv> nghttp2_nvs;
   nghttp2_nvs.reserve(num_headers);
@@ -82,6 +84,10 @@ std::vector<nghttp2_nv> GetNghttp2Nvs(absl::Span<const Header> headers) {
     header.valuelen = value.size();
     if (no_copy_value) {
       flags |= NGHTTP2_NV_FLAG_NO_COPY_VALUE;
+    }
+    if (never_indexing_policy != nullptr && *never_indexing_policy != nullptr &&
+        (*never_indexing_policy)(name, value)) {
+      flags |= NGHTTP2_NV_FLAG_NO_INDEX;
     }
     header.flags = flags;
     nghttp2_nvs.push_back(std::move(header));

--- a/quiche/http2/adapter/nghttp2_util.h
+++ b/quiche/http2/adapter/nghttp2_util.h
@@ -42,8 +42,13 @@ absl::string_view ToStringView(uint8_t* pointer, size_t length);
 absl::string_view ToStringView(const uint8_t* pointer, size_t length);
 
 // Returns the nghttp2 header structure from the given |headers|, which
-// must have the correct pseudoheaders preceding other headers.
-std::vector<nghttp2_nv> GetNghttp2Nvs(absl::Span<const Header> headers);
+// must have the correct pseudoheaders preceding other headers. If
+// |never_indexing_policy| is non-null and holds a callable, headers for which
+// it returns true are flagged NGHTTP2_NV_FLAG_NO_INDEX, causing nghttp2 to
+// encode them as HPACK "never indexed" literals (RFC 7541 Section 6.2.3).
+std::vector<nghttp2_nv> GetNghttp2Nvs(
+    absl::Span<const Header> headers,
+    const NeverIndexingPolicy* never_indexing_policy = nullptr);
 
 // Returns the nghttp2 header structure from the given response |headers|, with
 // the :status pseudoheader first based on the given |response_code|. The

--- a/quiche/http2/adapter/oghttp2_adapter.cc
+++ b/quiche/http2/adapter/oghttp2_adapter.cc
@@ -53,6 +53,10 @@ void OgHttp2Adapter::SubmitPing(Http2PingId ping_id) {
   session_.EnqueueFrame(std::make_unique<SpdyPingIR>(ping_id));
 }
 
+void OgHttp2Adapter::SetNeverIndexingPolicy(NeverIndexingPolicy policy) {
+  session_.SetNeverIndexingPolicy(std::move(policy));
+}
+
 void OgHttp2Adapter::SubmitShutdownNotice() {
   session_.StartGracefulShutdown();
 }

--- a/quiche/http2/adapter/oghttp2_adapter.h
+++ b/quiche/http2/adapter/oghttp2_adapter.h
@@ -30,6 +30,7 @@ class QUICHE_EXPORT OgHttp2Adapter : public Http2Adapter {
                                Http2StreamId parent_stream_id, int weight,
                                bool exclusive) override;
   void SubmitPing(Http2PingId ping_id) override;
+  void SetNeverIndexingPolicy(NeverIndexingPolicy policy) override;
   void SubmitShutdownNotice() override;
   void SubmitGoAway(Http2StreamId last_accepted_stream_id,
                     Http2ErrorCode error_code,

--- a/quiche/http2/adapter/oghttp2_adapter_test.cc
+++ b/quiche/http2/adapter/oghttp2_adapter_test.cc
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "quiche/http2/adapter/http2_protocol.h"
 #include "quiche/http2/adapter/http2_visitor_interface.h"
@@ -1691,6 +1692,75 @@ TEST(OgHttp2AdapterTest, ClientHandlesTrailers) {
   result = adapter->Send();
   EXPECT_EQ(0, result);
   EXPECT_THAT(visitor.data(), EqualsFrames({SpdyFrameType::SETTINGS}));
+}
+
+TEST(OgHttp2AdapterTest, ClientSubmitRequestWithNeverIndexingPolicy) {
+  // Huffman coding is disabled so the encoded header block contains
+  // predictable byte sequences that can be asserted on directly.
+  OgHttp2Adapter::Options options;
+  options.perspective = Perspective::kClient;
+  options.compression_option = OgHttp2Adapter::Options::DISABLE_HUFFMAN;
+
+  const std::vector<Header> headers =
+      ToHeaders({{":method", "GET"},
+                 {":scheme", "http"},
+                 {":authority", "example.com"},
+                 {":path", "/this/is/request/one"},
+                 {"x-request-id", "12345678-abcd"}});
+
+  // The literal name and value, as they appear after the representation's
+  // opcode and length prefixes.
+  const absl::string_view kNameAndValue(
+      "\x0c"
+      "x-request-id"
+      "\x0d"
+      "12345678-abcd");
+  // RFC 7541 Section 6.2.3: literal header field never indexed, with literal
+  // (non-indexed) name.
+  const std::string kNeverIndexed = absl::StrCat("\x10", kNameAndValue);
+  // RFC 7541 Section 6.2.1: literal header field with incremental indexing.
+  const std::string kIncrementallyIndexed = absl::StrCat("\x40", kNameAndValue);
+
+  TestVisitor visitor;
+  auto adapter = OgHttp2Adapter::Create(visitor, options);
+  adapter->SetNeverIndexingPolicy(
+      [](absl::string_view name, absl::string_view /*value*/) {
+        return name == "x-request-id";
+      });
+
+  const int32_t stream_id = adapter->SubmitRequest(headers, true, nullptr);
+  ASSERT_GT(stream_id, 0);
+  EXPECT_CALL(visitor, OnBeforeFrameSent(SETTINGS, 0, _, 0x0));
+  EXPECT_CALL(visitor, OnFrameSent(SETTINGS, 0, _, 0x0, 0));
+  EXPECT_CALL(visitor, OnBeforeFrameSent(HEADERS, stream_id, _, 0x5));
+  EXPECT_CALL(visitor, OnFrameSent(HEADERS, stream_id, _, 0x5, 0));
+  EXPECT_EQ(0, adapter->Send());
+
+  EXPECT_THAT(visitor.data(), testing::HasSubstr(kNeverIndexed));
+  EXPECT_THAT(visitor.data(),
+              testing::Not(testing::HasSubstr(kIncrementallyIndexed)));
+
+  // For comparison, an adapter without the policy emits the same header with
+  // incremental indexing, inserting it into the HPACK dynamic table.
+  TestVisitor control_visitor;
+  auto control_adapter = OgHttp2Adapter::Create(control_visitor, options);
+  const int32_t control_stream_id =
+      control_adapter->SubmitRequest(headers, true, nullptr);
+  ASSERT_GT(control_stream_id, 0);
+  EXPECT_CALL(control_visitor, OnBeforeFrameSent(SETTINGS, 0, _, 0x0));
+  EXPECT_CALL(control_visitor, OnFrameSent(SETTINGS, 0, _, 0x0, 0));
+  EXPECT_CALL(control_visitor,
+              OnBeforeFrameSent(HEADERS, control_stream_id, _, 0x5));
+  EXPECT_CALL(control_visitor, OnFrameSent(HEADERS, control_stream_id, _, 0x5, 0));
+  EXPECT_EQ(0, control_adapter->Send());
+
+  EXPECT_THAT(control_visitor.data(), testing::HasSubstr(kIncrementallyIndexed));
+  EXPECT_THAT(control_visitor.data(),
+              testing::Not(testing::HasSubstr(kNeverIndexed)));
+
+  // The never-indexed header was not inserted into the dynamic table.
+  EXPECT_LT(adapter->GetHpackEncoderDynamicTableSize(),
+            control_adapter->GetHpackEncoderDynamicTableSize());
 }
 
 TEST(OgHttp2AdapterTest, ClientSendsTrailers) {

--- a/quiche/http2/adapter/oghttp2_session.cc
+++ b/quiche/http2/adapter/oghttp2_session.cc
@@ -583,6 +583,10 @@ int OgHttp2Session::Consume(Http2StreamId stream_id, size_t num_bytes) {
   return 0;  // Remove?
 }
 
+void OgHttp2Session::SetNeverIndexingPolicy(NeverIndexingPolicy policy) {
+  framer_.GetHpackEncoder()->SetNeverIndexingPolicy(std::move(policy));
+}
+
 void OgHttp2Session::StartGracefulShutdown() {
   if (IsServerSession()) {
     if (!queued_goaway_) {

--- a/quiche/http2/adapter/oghttp2_session.h
+++ b/quiche/http2/adapter/oghttp2_session.h
@@ -112,6 +112,11 @@ class QUICHE_EXPORT OgHttp2Session : public Http2Session,
   // sent.
   void StartGracefulShutdown();
 
+  // Headers for which |policy| returns true are encoded as literal header
+  // fields that are never indexed (RFC 7541 Section 6.2.3). See
+  // Http2Adapter::SetNeverIndexingPolicy().
+  void SetNeverIndexingPolicy(NeverIndexingPolicy policy);
+
   // Invokes the visitor's OnReadyToSend() method for serialized frames and
   // DataFrameSource::Send() for data frames.
   int Send();

--- a/quiche/http2/core/spdy_framer.h
+++ b/quiche/http2/core/spdy_framer.h
@@ -222,6 +222,13 @@ class QUICHE_EXPORT SpdyFramer {
     GetHpackEncoder()->SetIndexingPolicy(std::move(policy));
   }
 
+  // Headers for which |policy| returns true are encoded as literal header
+  // fields that are never indexed (RFC 7541 Section 6.2.3). See
+  // HpackEncoder::SetNeverIndexingPolicy().
+  void SetHpackNeverIndexingPolicy(HpackEncoder::IndexingPolicy policy) {
+    GetHpackEncoder()->SetNeverIndexingPolicy(std::move(policy));
+  }
+
   // Updates the maximum size of the header encoder compression table.
   void UpdateHeaderEncoderTableSize(uint32_t value);
 

--- a/quiche/http2/hpack/hpack_constants.h
+++ b/quiche/http2/hpack/hpack_constants.h
@@ -62,8 +62,7 @@ inline constexpr HpackPrefix kLiteralIncrementalIndexOpcode = {0b01, 2};
 inline constexpr HpackPrefix kLiteralNoIndexOpcode = {0b0000, 4};
 
 // RFC 7541, 6.2.3: Opcode for a literal header field which is never indexed.
-// Currently unused.
-// const HpackPrefix kLiteralNeverIndexOpcode = {0b0001, 4};
+inline constexpr HpackPrefix kLiteralNeverIndexOpcode = {0b0001, 4};
 
 // RFC 7541, 6.3: Opcode for maximum header table size update. Begins a
 // varint-encoded table size with a 5-bit prefix.

--- a/quiche/http2/hpack/hpack_encoder.cc
+++ b/quiche/http2/hpack/hpack_encoder.cc
@@ -82,6 +82,12 @@ bool DefaultPolicy(absl::string_view name, absl::string_view /* value */) {
   return true;
 }
 
+// The default never-indexing policy: no headers are never-indexed.
+bool DefaultNeverIndexingPolicy(absl::string_view /*name*/,
+                                absl::string_view /*value*/) {
+  return false;
+}
+
 }  // namespace
 
 HpackEncoder::HpackEncoder()
@@ -89,12 +95,21 @@ HpackEncoder::HpackEncoder()
       min_table_size_setting_received_(std::numeric_limits<size_t>::max()),
       listener_(NoOpListener),
       should_index_(DefaultPolicy),
+      never_index_(DefaultNeverIndexingPolicy),
       enable_dynamic_table_(true),
       enable_huffman_(true),
       should_emit_table_size_(false),
       crumble_cookies_(true) {}
 
 HpackEncoder::~HpackEncoder() = default;
+
+void HpackEncoder::SetNeverIndexingPolicy(IndexingPolicy policy) {
+  if (policy == nullptr) {
+    never_index_ = DefaultNeverIndexingPolicy;
+  } else {
+    never_index_ = std::move(policy);
+  }
+}
 
 std::string HpackEncoder::EncodeHeaderBlock(
     const quiche::HttpHeaderBlock& header_set) {
@@ -142,7 +157,9 @@ std::string HpackEncoder::EncodeRepresentations(RepresentationIterator* iter) {
   while (iter->HasNext()) {
     const auto header = iter->Next();
     listener_(header.first, header.second);
-    if (enable_dynamic_table_) {
+    if (never_index_(header.first, header.second)) {
+      EmitNeverIndexedLiteral(header);
+    } else if (enable_dynamic_table_) {
       size_t index =
           header_table_.GetByNameAndValue(header.first, header.second);
       if (index != kHpackEntryNotFound) {
@@ -189,7 +206,20 @@ void HpackEncoder::EmitIndexedLiteral(const Representation& representation) {
 void HpackEncoder::EmitNonIndexedLiteral(const Representation& representation) {
   QUICHE_DVLOG(2) << "Emitting nonindexed literal: (" << representation.first
                   << ", " << representation.second << ")";
-  output_stream_.AppendPrefix(kLiteralNoIndexOpcode);
+  EmitLiteralWithoutIndexing(representation, kLiteralNoIndexOpcode);
+}
+
+void HpackEncoder::EmitNeverIndexedLiteral(
+    const Representation& representation) {
+  QUICHE_DVLOG(2) << "Emitting never-indexed literal: ("
+                  << representation.first << ", " << representation.second
+                  << ")";
+  EmitLiteralWithoutIndexing(representation, kLiteralNeverIndexOpcode);
+}
+
+void HpackEncoder::EmitLiteralWithoutIndexing(
+    const Representation& representation, HpackPrefix opcode) {
+  output_stream_.AppendPrefix(opcode);
   size_t name_index = header_table_.GetByName(representation.first);
   if (enable_dynamic_table_ && name_index != kHpackEntryNotFound) {
     output_stream_.AppendUint32(name_index);
@@ -372,7 +402,9 @@ std::string HpackEncoder::Encoderator::Next(size_t max_encoded_bytes) {
          encoder_->output_stream_.size() <= max_encoded_bytes) {
     const Representation header = header_it_->Next();
     encoder_->listener_(header.first, header.second);
-    if (enable_dynamic_table) {
+    if (encoder_->never_index_(header.first, header.second)) {
+      encoder_->EmitNeverIndexedLiteral(header);
+    } else if (enable_dynamic_table) {
       size_t index = encoder_->header_table_.GetByNameAndValue(header.first,
                                                                header.second);
       if (index != kHpackEntryNotFound) {

--- a/quiche/http2/hpack/hpack_encoder.h
+++ b/quiche/http2/hpack/hpack_encoder.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "absl/strings/string_view.h"
+#include "quiche/http2/hpack/hpack_constants.h"
 #include "quiche/http2/hpack/hpack_header_table.h"
 #include "quiche/http2/hpack/hpack_output_stream.h"
 #include "quiche/common/http/http_header_block.h"
@@ -95,6 +96,21 @@ class QUICHE_EXPORT HpackEncoder {
     should_index_ = std::move(policy);
   }
 
+  // This HpackEncoder will use |policy| to determine whether a header
+  // name-value pair must be encoded as a literal header field that is never
+  // indexed (RFC 7541 Section 6.2.3). Headers for which |policy| returns true
+  // are never inserted into the dynamic table and never emitted as indexed
+  // representations, and intermediaries are instructed not to index them
+  // either. This takes precedence over the policy set via SetIndexingPolicy().
+  // When cookie crumbling is enabled, the policy is evaluated once per cookie
+  // crumb. Note that the header name may still be represented by a table
+  // index, as permitted by RFC 7541 Section 6.2.3; only the value is always
+  // emitted as a literal. A name-value pair inserted into the dynamic table
+  // before the policy matched it remains in the table. A null (default
+  // constructed) |policy| restores the default behavior, in which no headers
+  // are never-indexed.
+  void SetNeverIndexingPolicy(IndexingPolicy policy);
+
   // |listener| will be invoked for each header name-value pair processed by
   // this encoder.
   void SetHeaderListener(HeaderListener listener) {
@@ -133,7 +149,14 @@ class QUICHE_EXPORT HpackEncoder {
   // Emits a literal representation (Section 7.2).
   void EmitIndexedLiteral(const Representation& representation);
   void EmitNonIndexedLiteral(const Representation& representation);
+  void EmitNeverIndexedLiteral(const Representation& representation);
   void EmitLiteral(const Representation& representation);
+
+  // Shared implementation for the literal representations that do not add to
+  // the dynamic table (Sections 6.2.2 and 6.2.3), which differ only in
+  // |opcode|.
+  void EmitLiteralWithoutIndexing(const Representation& representation,
+                                  HpackPrefix opcode);
 
   // Emits a Huffman or identity string (whichever is smaller).
   void EmitString(absl::string_view str);
@@ -157,6 +180,7 @@ class QUICHE_EXPORT HpackEncoder {
   size_t min_table_size_setting_received_;
   HeaderListener listener_;
   IndexingPolicy should_index_;
+  IndexingPolicy never_index_;
   bool enable_dynamic_table_;
   bool enable_huffman_;
   bool should_emit_table_size_;

--- a/quiche/http2/hpack/hpack_encoder_test.cc
+++ b/quiche/http2/hpack/hpack_encoder_test.cc
@@ -204,6 +204,19 @@ class HpackEncoderTest
     expected_.AppendUint32(key_index);
     ExpectString(&expected_, value);
   }
+  void ExpectNeverIndexedLiteral(absl::string_view name,
+                                 absl::string_view value) {
+    expected_.AppendPrefix(kLiteralNeverIndexOpcode);
+    expected_.AppendUint32(0);
+    ExpectString(&expected_, name);
+    ExpectString(&expected_, value);
+  }
+  void ExpectNeverIndexedLiteralWithNameIndex(size_t key_index,
+                                              absl::string_view value) {
+    expected_.AppendPrefix(kLiteralNeverIndexOpcode);
+    expected_.AppendUint32(key_index);
+    ExpectString(&expected_, value);
+  }
   void ExpectString(HpackOutputStream* stream, absl::string_view str) {
     size_t encoded_size =
         peer_.huffman_enabled() ? http2::HuffmanSize(str) : str.size();
@@ -521,6 +534,133 @@ TEST_P(HpackEncoderTest, MultiValuedHeadersNotCrumbled) {
   ExpectIndexedLiteral("foo", "bar, baz");
   quiche::HttpHeaderBlock headers;
   headers["foo"] = "bar, baz";
+  CompareWithExpectedEncoding(headers);
+}
+
+TEST_P(HpackEncoderTest, NeverIndexedLiteral) {
+  encoder_.SetNeverIndexingPolicy(
+      [](absl::string_view name, absl::string_view /*value*/) {
+        return name == "x-request-id";
+      });
+
+  // "key3" is not covered by the policy and is indexed as usual.
+  ExpectIndexedLiteral("key3", "value3");
+  // The high-entropy value is compressible, so the string itself is still
+  // Huffman-coded; only indexing is affected.
+  ExpectNeverIndexedLiteral("x-request-id", "abcd-1234-efgh-5678");
+
+  quiche::HttpHeaderBlock headers;
+  headers["key3"] = "value3";
+  headers["x-request-id"] = "abcd-1234-efgh-5678";
+  CompareWithExpectedEncoding(headers);
+}
+
+TEST_P(HpackEncoderTest, NeverIndexedLiteralSupersedesTableMatch) {
+  // |key_2_| has a (name, value) match in the dynamic table, which would
+  // normally be emitted as an indexed representation. The never-indexing
+  // policy takes precedence, though the name may still be represented by a
+  // table index.
+  encoder_.SetNeverIndexingPolicy(
+      [this](absl::string_view name, absl::string_view /*value*/) {
+        return name == key_2_->name();
+      });
+
+  ExpectNeverIndexedLiteralWithNameIndex(
+      peer_.table()->GetByName(key_2_->name()), key_2_->value());
+
+  quiche::HttpHeaderBlock headers;
+  headers[key_2_->name()] = key_2_->value();
+  CompareWithExpectedEncoding(headers);
+}
+
+TEST_P(HpackEncoderTest, NeverIndexedLiteralSupersedesIndexingPolicy) {
+  // Even with an indexing policy that would insert everything into the
+  // dynamic table, never-indexed headers are not inserted.
+  encoder_.SetIndexingPolicy(
+      [](absl::string_view /*name*/, absl::string_view /*value*/) {
+        return true;
+      });
+  encoder_.SetNeverIndexingPolicy(
+      [](absl::string_view name, absl::string_view /*value*/) {
+        return name == "key3";
+      });
+
+  ExpectNeverIndexedLiteral("key3", "value3");
+
+  quiche::HttpHeaderBlock headers;
+  headers["key3"] = "value3";
+  CompareWithExpectedEncoding(headers);
+
+  // No entry was inserted into the dynamic table.
+  EXPECT_EQ(kInitialDynamicTableSize, encoder_.GetDynamicTableSize());
+  EXPECT_EQ(kHpackEntryNotFound,
+            peer_.table()->GetByNameAndValue("key3", "value3"));
+}
+
+TEST_P(HpackEncoderTest, NeverIndexedLiteralWithCompressionDisabled) {
+  // The never-indexed representation is still emitted when the dynamic table
+  // is disabled, since it also instructs intermediaries not to index.
+  encoder_.DisableCompression();
+  encoder_.SetNeverIndexingPolicy(
+      [](absl::string_view name, absl::string_view /*value*/) {
+        return name == "x-request-id";
+      });
+
+  ExpectNonIndexedLiteral("key3", "value3");
+  ExpectNeverIndexedLiteral("x-request-id", "abcd-1234-efgh-5678");
+
+  quiche::HttpHeaderBlock headers;
+  headers["key3"] = "value3";
+  headers["x-request-id"] = "abcd-1234-efgh-5678";
+  CompareWithExpectedEncoding(headers);
+}
+
+TEST_P(HpackEncoderTest, NeverIndexedCookieIsEvaluatedPerCrumb) {
+  encoder_.SetNeverIndexingPolicy(
+      [](absl::string_view name, absl::string_view /*value*/) {
+        return name == "cookie";
+      });
+
+  // Each crumb is emitted as a never-indexed literal, including those with
+  // (name, value) matches in the dynamic table.
+  const size_t cookie_name_index = peer_.table()->GetByName("cookie");
+  ExpectNeverIndexedLiteralWithNameIndex(cookie_name_index, "a=bb");
+  ExpectNeverIndexedLiteralWithNameIndex(cookie_name_index, "c=dd");
+  ExpectNeverIndexedLiteralWithNameIndex(cookie_name_index, "e=ff");
+
+  quiche::HttpHeaderBlock headers;
+  headers["cookie"] = "a=bb; c=dd; e=ff";
+  CompareWithExpectedEncoding(headers);
+}
+
+TEST_P(HpackEncoderTest, ValueBasedNeverIndexingPolicySeesCookieCrumbs) {
+  // A value-based policy is evaluated against individual cookie crumbs.
+  encoder_.SetNeverIndexingPolicy(
+      [](absl::string_view /*name*/, absl::string_view value) {
+        return value == "e=ff";
+      });
+
+  ExpectIndex(DynamicIndexToWireIndex(cookie_a_index_));
+  ExpectIndex(DynamicIndexToWireIndex(cookie_c_index_));
+  ExpectNeverIndexedLiteralWithNameIndex(peer_.table()->GetByName("cookie"),
+                                         "e=ff");
+
+  quiche::HttpHeaderBlock headers;
+  headers["cookie"] = "a=bb; c=dd; e=ff";
+  CompareWithExpectedEncoding(headers);
+}
+
+TEST_P(HpackEncoderTest, NullNeverIndexingPolicyRestoresDefault) {
+  encoder_.SetNeverIndexingPolicy(
+      [](absl::string_view name, absl::string_view /*value*/) {
+        return name == "key3";
+      });
+  encoder_.SetNeverIndexingPolicy(HpackEncoder::IndexingPolicy());
+
+  ExpectIndexedLiteral("key3", "value3");
+
+  quiche::HttpHeaderBlock headers;
+  headers["key3"] = "value3";
   CompareWithExpectedEncoding(headers);
 }
 

--- a/quiche/http2/hpack/hpack_round_trip_test.cc
+++ b/quiche/http2/hpack/hpack_round_trip_test.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/string_view.h"
 #include "quiche/http2/core/recording_headers_handler.h"
 #include "quiche/http2/hpack/hpack_decoder_adapter.h"
 #include "quiche/http2/hpack/hpack_encoder.h"
@@ -110,6 +111,24 @@ TEST_P(HpackRoundTripTest, ResponseFixtures) {
         "foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU;"
         " max-age=3600; version=1";
     headers["multivalue"] = std::string("foo\0bar", 7);
+    EXPECT_TRUE(RoundTrip(headers));
+  }
+}
+
+TEST_P(HpackRoundTripTest, NeverIndexedHeaders) {
+  encoder_.SetNeverIndexingPolicy(
+      [](absl::string_view name, absl::string_view /*value*/) {
+        return name == "x-request-id" || name == "cookie";
+      });
+  // Encode the same block twice; never-indexed headers do not populate the
+  // dynamic table, so repeated blocks must still decode correctly.
+  for (int i = 0; i < 2; ++i) {
+    quiche::HttpHeaderBlock headers;
+    headers[":method"] = "GET";
+    headers[":path"] = "/";
+    headers["cookie"] = "foo=bar; baz=bing";
+    headers["x-request-id"] = "e77bd1a9-2827-46b0-b8b9-372a4b0d47b1";
+    headers["accept"] = "text/html";
     EXPECT_TRUE(RoundTrip(headers));
   }
 }


### PR DESCRIPTION
Adds `Http2Adapter::SetNeverIndexingPolicy()`, a callback that decides whether a header field should be encoded as a "Literal Header Field Never Indexed" (RFC 7541 [Section 6.2.3](https://www.rfc-editor.org/rfc/rfc7541#section-6.2.3)). Matching headers are never inserted into the HPACK dynamic table, and intermediaries are instructed not to index them either. This is useful for high-entropy headers such as request and trace IDs, which churn the dynamic table without any compression benefit.

Both adapters honor the policy:
- `OgHttp2Adapter` forwards it to the `HpackEncoder`, which gains a never-indexed emit path checked ahead of all other indexing decisions (including existing dynamic table entries).
- `NgHttp2Adapter` translates it to `NGHTTP2_NV_FLAG_NO_INDEX` when submitting request headers, response headers, and trailers.

Motivated by envoyproxy/envoy#46584, where Envoy wants to let operators configure upstream request headers as never-indexed; @adisuissa suggested the change should land in QUICHE first. With this API, the Envoy change reduces to a config field and a small policy wiring in its HTTP/2 codec.

Covered by new tests: exact wire-format assertions in `hpack_encoder_test.cc` (all three encode strategies), a decode round trip in `hpack_round_trip_test.cc`, and end-to-end adapter tests in `oghttp2_adapter_test.cc` and `nghttp2_adapter_test.cc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) using the Claude Fable 5 model