### PR TITLE
Issue #62 fix. Sync the first client CID length with the DeterministicConnectionIdGenerator::expected_connection_id_length_ 

### DIFF
--- a/quiche/quic/core/deterministic_connection_id_generator.cc
+++ b/quiche/quic/core/deterministic_connection_id_generator.cc
@@ -13,8 +13,13 @@
 namespace quic {
 
 DeterministicConnectionIdGenerator::DeterministicConnectionIdGenerator(
-    uint8_t expected_connection_id_length)
-    : expected_connection_id_length_(expected_connection_id_length) {
+    uint8_t expected_connection_id_length) {
+  set_expected_connection_id_length(expected_connection_id_length);
+}
+
+void DeterministicConnectionIdGenerator::set_expected_connection_id_length(
+    uint8_t expected_connection_id_length) {
+  expected_connection_id_length_ = expected_connection_id_length;
   if (expected_connection_id_length_ >
       kQuicMaxConnectionIdWithLengthPrefixLength) {
     QUIC_BUG(quic_bug_465151159_01)

--- a/quiche/quic/core/deterministic_connection_id_generator.h
+++ b/quiche/quic/core/deterministic_connection_id_generator.h
@@ -17,7 +17,11 @@ namespace quic {
 class QUICHE_EXPORT DeterministicConnectionIdGenerator
     : public ConnectionIdGeneratorInterface {
  public:
-  DeterministicConnectionIdGenerator(uint8_t expected_connection_id_length);
+  explicit DeterministicConnectionIdGenerator(
+      uint8_t expected_connection_id_length);
+
+  // Sets the length of the connection IDs generated from now on.
+  void set_expected_connection_id_length(uint8_t expected_connection_id_length);
 
   // Hashes |original| to create a new connection ID.
   std::optional<QuicConnectionId> GenerateNextConnectionId(
@@ -32,7 +36,7 @@ class QUICHE_EXPORT DeterministicConnectionIdGenerator
   }
 
  private:
-  const uint8_t expected_connection_id_length_;
+  uint8_t expected_connection_id_length_;
 };
 
 }  // namespace quic

--- a/quiche/quic/core/http/end_to_end_test.cc
+++ b/quiche/quic/core/http/end_to_end_test.cc
@@ -1141,6 +1141,9 @@ class EndToEndTest : public QuicTestWithParam<TestParams> {
   void TestMultiPacketChaosProtection(int num_packets, bool drop_first_packet,
                                       bool kyber = false);
 
+  void ConnectionMigrationNonZeroConnectionIDClientIPChange(
+                                          uint8_t client_connection_id_length);
+
   quiche::test::ScopedEnvironmentForThreads environment_;
   bool initialized_;
   // If true, the Initialize() function will create |client_| and starts to
@@ -3613,12 +3616,24 @@ TEST_P(EndToEndTest, IetfConnectionMigrationClientIPChangedMultipleTimes) {
 
 TEST_P(EndToEndTest,
        ConnectionMigrationWithNonZeroConnectionIDClientIPChangedMultipleTimes) {
+  ConnectionMigrationNonZeroConnectionIDClientIPChange(
+      kQuicDefaultConnectionIdLength);
+}
+
+TEST_P(EndToEndTest,
+        ConnectionMigrationWithMaxConnectionIDClientIPChangedMultipleTimes) {
+  ConnectionMigrationNonZeroConnectionIDClientIPChange(
+      kQuicMaxConnectionIdWithLengthPrefixLength);
+}
+
+void EndToEndTest::ConnectionMigrationNonZeroConnectionIDClientIPChange(
+                                          uint8_t client_connection_id_length) {
   if (!version_.IsIetfQuic() ||
       GetQuicFlag(quic_enforce_strict_amplification_factor)) {
     ASSERT_TRUE(Initialize());
     return;
   }
-  override_client_connection_id_length_ = kQuicDefaultConnectionIdLength;
+  override_client_connection_id_length_ = client_connection_id_length;
   ASSERT_TRUE(Initialize());
   SendSynchronousFooRequestAndCheckResponse();
 

--- a/quiche/quic/test_tools/quic_test_client.cc
+++ b/quiche/quic/test_tools/quic_test_client.cc
@@ -223,9 +223,7 @@ MockableQuicClient::MockableQuicClient(
           std::make_unique<MockableQuicClientDefaultNetworkHelper>(event_loop,
                                                                    this),
           std::make_unique<RecordingProofVerifier>(std::move(proof_verifier)),
-          std::move(session_cache)),
-      override_client_connection_id_(EmptyQuicConnectionId()),
-      client_connection_id_overridden_(false) {}
+          std::move(session_cache)) {}
 
 MockableQuicClient::~MockableQuicClient() {
   if (connected()) {
@@ -245,27 +243,11 @@ MockableQuicClient::mockable_network_helper() const {
       default_network_helper());
 }
 
-QuicConnectionId MockableQuicClient::GetClientConnectionId() {
-  if (client_connection_id_overridden_) {
-    return override_client_connection_id_;
-  }
-  if (override_client_connection_id_length_ >= 0) {
-    return QuicUtils::CreateRandomConnectionId(
-        override_client_connection_id_length_);
-  }
-  return QuicDefaultClient::GetClientConnectionId();
-}
-
 std::unique_ptr<QuicMigrationHelper>
 MockableQuicClient::CreateQuicMigrationHelper() {
   auto migration_helper = std::make_unique<QuicTestMigrationHelper>(*this);
   migration_helper_ = migration_helper.get();
   return migration_helper;
-}
-
-void MockableQuicClient::UseClientConnectionIdLength(
-    int client_connection_id_length) {
-  override_client_connection_id_length_ = client_connection_id_length;
 }
 
 void MockableQuicClient::UseWriter(QuicPacketWriterWrapper* writer) {
@@ -785,7 +767,7 @@ void QuicTestClient::UseConnectionIdLength(
 void QuicTestClient::UseClientConnectionIdLength(
     uint8_t client_connection_id_length) {
   QUICHE_DCHECK(!connected());
-  client_->UseClientConnectionIdLength(client_connection_id_length);
+  client_->set_client_connection_id_length(client_connection_id_length);
 }
 
 bool QuicTestClient::MigrateSocket(const QuicIpAddress& new_host) {

--- a/quiche/quic/test_tools/quic_test_client.h
+++ b/quiche/quic/test_tools/quic_test_client.h
@@ -182,9 +182,7 @@ class MockableQuicClient : public QuicDefaultClient {
         enable_web_transport());
   }
 
-  QuicConnectionId GetClientConnectionId() override;
   std::unique_ptr<QuicMigrationHelper> CreateQuicMigrationHelper() override;
-  void UseClientConnectionIdLength(int client_connection_id_length);
 
   void UseWriter(QuicPacketWriterWrapper* writer);
   void set_peer_address(const QuicSocketAddress& address);
@@ -208,11 +206,6 @@ class MockableQuicClient : public QuicDefaultClient {
   }
 
  private:
-  // Client connection ID to use, if client_connection_id_overridden_.
-  // TODO(wub): Move client_connection_id_(length_) overrides to QuicClientBase.
-  QuicConnectionId override_client_connection_id_;
-  bool client_connection_id_overridden_;
-  int override_client_connection_id_length_ = -1;
   CachedNetworkParameters cached_network_paramaters_;
   // Owned by the base class.
   QuicTestMigrationHelper* migration_helper_ = nullptr;
@@ -375,9 +368,6 @@ class QuicTestClient : public QuicSpdyStream::Visitor {
   // Configures client_ to use a specific server connection ID length instead
   // of the default of kQuicDefaultConnectionIdLength.
   void UseConnectionIdLength(uint8_t server_connection_id_length);
-  // Configures client_ to use a specific client connection ID instead of an
-  // empty one.
-  void UseClientConnectionId(QuicConnectionId client_connection_id);
   // Configures client_ to use a specific client connection ID length instead
   // of the default of zero.
   void UseClientConnectionIdLength(uint8_t client_connection_id_length);

--- a/quiche/quic/tools/quic_client_base.cc
+++ b/quiche/quic/tools/quic_client_base.cc
@@ -484,6 +484,14 @@ QuicConnectionId QuicClientBase::GetClientConnectionId() {
   return QuicUtils::CreateRandomConnectionId(client_connection_id_length_);
 }
 
+void QuicClientBase::set_client_connection_id_length(
+    uint8_t client_connection_id_length) {
+  QUICHE_DCHECK(!connected());
+  client_connection_id_length_ = client_connection_id_length;
+  connection_id_generator_.set_expected_connection_id_length(
+      client_connection_id_length);
+}
+
 bool QuicClientBase::CanReconnectWithDifferentVersion(
     ParsedQuicVersion* version) const {
   if (session_ == nullptr || session_->connection() == nullptr ||

--- a/quiche/quic/tools/quic_client_base.h
+++ b/quiche/quic/tools/quic_client_base.h
@@ -317,9 +317,10 @@ class QuicClientBase : public QuicSession::Visitor {
     server_connection_id_length_ = server_connection_id_length;
   }
 
-  void set_client_connection_id_length(uint8_t client_connection_id_length) {
-    client_connection_id_length_ = client_connection_id_length;
-  }
+  // Sets the length of the client connection IDs this client generates,
+  // including the ones self-issued after the handshake. Must be called before
+  // the connection is created.
+  void set_client_connection_id_length(uint8_t client_connection_id_length);
 
   bool HasPendingPathValidation();
 


### PR DESCRIPTION
## Problem

MockableQuicClient::UseClientConnectionIdLength() updated override_client_connection_id_length_, which was used to create the initial CID in MockableQuicClient::GetClientConnectionId(), but it did not touch connection_id_generator_, which is constructed with expected_connection_id_length_ == kQuicDefaultConnectionIdLength.

Setting the initial CID also sets the framer's expected client CID length for whole connection in QuicConnection::set_client_connection_id.

As a result, the first CID had the length configured through MockableQuicClient::UseClientConnectionIdLength(), while every subsequent CID had DeterministicConnectionIdGenerator::expected_connection_id_length_, which is different to QuicFramer::expected_client_connection_id_length_. 

Any packet carrying a CID of a different length than the one established by QuicConnection::set_client_connection_id is dropped rather than processed.

## Solution

RFC 9000, Section 10.3.2 states that 
```An endpoint that uses this design MUST either use the same connection ID length for all connections or encode the length of the connection ID such that it can be recovered without state. In addition, it cannot provide a zero-length connection ID.```

In the current QUIC implementation, the CID length is set once in QuicClientBase::StartConnect and stays constant for the entire lifetime of the connection.

Since DeterministicConnectionIdGenerator has the same lifetime as QuicClientBase, expected_connection_id_length_ is no longer const and a setter for it was added. QuicClientBase::set_client_connection_id_length() now keeps the generator in sync.

The CID length must be changed before the first handshake to avoid CIDs of different lengths within one connection, so QuicClientBase::set_client_connection_id_length() carries a QUICHE_DCHECK(!connected()).

The following overrides were also removed from quic_test_client.h:
```
  // Client connection ID to use, if client_connection_id_overridden_.
  // TODO(wub): Move client_connection_id_(length_) overrides to QuicClientBase.
  QuicConnectionId override_client_connection_id_;
  bool client_connection_id_overridden_;
  int override_client_connection_id_length_ = -1;
```
as this commit implements exactly that logic in QuicClientBase.

## Testing

The multi-migration end-to-end test is now parameterized by the client connection ID length and additionally runs with kQuicMaxConnectionIdWithLengthPrefixLength, which fails without this fix.

```
bazel-bin/quiche/end_to_end_test --gtest_filter='*ConnectionMigrationWithMaxConnectionIDClientIPChangedMultipleTimes*:*ConnectionMigrationWithNonZeroConnectionIDClientIPChangedMultipleTimes*'
```

Issue [#62](https://github.com/google/quiche/issues/62)